### PR TITLE
Implement #9 Make sure the active UVs are the first on every mesh

### DIFF
--- a/.github/workflows/webhook_process_asset.yml
+++ b/.github/workflows/webhook_process_asset.yml
@@ -64,7 +64,7 @@ jobs:
         run: python3 generate_gltf.py
 
   GLTF_GODOT:
-    name: Public, Validated and Model -> generate GLTF
+    name: Public, Validated and Model -> generate Godot GLTF
     runs-on: ubuntu-latest
     if: contains(fromJSON('["model",]'), github.event.inputs.asset_type || github.event.client_payload.asset_type) && 
       (github.event.inputs.verification_status == 'validated' || github.event.client_payload.verification_status == 'validated') &&

--- a/blender_bg_scripts/gltf_bg_blender.py
+++ b/blender_bg_scripts/gltf_bg_blender.py
@@ -12,7 +12,8 @@ parent_path = os.path.join(dir_path, os.path.pardir)
 sys.path.append(parent_path)
 
 
-# GLTF OPTIONS - check the default values on https://docs.blender.org/api/current/bpy.ops.export_scene.html
+# MARK: GLTF OPTS
+# check the default values on https://docs.blender.org/api/current/bpy.ops.export_scene.html
 dracoMeshCompression = {"export_draco_mesh_compression_enable": True} # default False, Draco compresses mesh, making the file smaller
 minimalGLTF = {
     "export_format": "GLB", # We want single GLTF binary file - the .GLB
@@ -25,7 +26,71 @@ maximalGLTF = minimalGLTF | { # Original settings by Vilem
     "export_image_quality": 50, # default 75 
     }
 
+# MARK: MODIFIERS
+def disable_subsurf_modifiers(obj):
+    for mod in obj.modifiers:
+        if mod.type != 'SUBSURF':
+            continue
+        mod.show_viewport = False
+        mod.show_render = False
+        print(f"----- disabled Subdivision Surface modifier for '{obj.name}'")
 
+# MARK: UV LAYERS
+def make_UV_active(obj, name):
+    uvs = obj.data.uv_layers
+    for uv in uvs:
+        if uv.name == name:
+            uvs.active = uv
+            return
+    print("Could not find:", name, "\n(this should never happen)")
+
+def move_UV_to_bottom(obj, index):
+    """This is a hack, because we cannot directly modify the obj.data.uv_layers.
+    So instead we copy inactive UVs (added to last position) and delete their original.
+    This effectively moves them on last position."""
+    uvs = obj.data.uv_layers
+    uvs.active_index = index
+    new_name = uvs.active.name
+
+    # set the context, so later we can add uv_texture
+    bpy.context.view_layer.objects.active = obj 
+    obj.select_set(True)
+    if bpy.ops.object.mode_set.poll():
+        bpy.ops.object.mode_set(mode='OBJECT')
+
+    bpy.ops.mesh.uv_texture_add()
+    make_UV_active(obj, new_name)
+    bpy.ops.mesh.uv_texture_remove()
+
+    uvs.active_index = len(uvs) - 1
+    uvs.active.name = new_name
+
+
+def make_active_UV_first(obj):
+    """Hacky function to change the order of UVs. Effectively copies UV one by one (to last position).
+    Skips the active UV, so in the end the active is on first place and all other UVs are after.
+    Keeps the order of all UVs, just the active is on first place.
+    """
+    uvs = obj.data.uv_layers
+    orig_name = uvs.active.name
+    orig_index = uvs.active_index
+    if orig_index == 0:
+        return
+
+    print(f"----- UVs before order: {[uv for uv in uvs]} ({uvs.active.name} is active)")
+    for i in range(len(uvs)):
+        if i == orig_index:
+            continue # do not move the active UV to bottom, keep it on top
+        elif i < orig_index:
+            move_UV_to_bottom(obj, 0)
+        else: # at this point active is on first place, so moving the second element to keep original order of other UVs
+            move_UV_to_bottom(obj, 1)
+
+    make_UV_active(obj, orig_name) #move_UV_to_bottom() plays with active, so we set it here to originally active UV
+    print(f"----- UVs before order: {[uv for uv in uvs]} ({uvs.active.name} is active)")
+
+    
+# MARK: GENERATE
 # ACCEPT different formats - like WEB (compressed GLTF), GODOT (uncompressed)
 def generate_gltf(json_result_path: str, target_format: str):
     """
@@ -35,21 +100,29 @@ def generate_gltf(json_result_path: str, target_format: str):
     filepath = bpy.data.filepath.replace('.blend', '.glb')
     
     # PREPARE ASSET (do things which cannot be set in GLTF export options)
-    # Disable Subdivision Surface modifiers
-    for obj in bpy.context.selected_objects:
+    print("=== ASSET PRE-PROCESSING ===")
+    for i, obj in enumerate(bpy.data.objects):
+        print(f"---- {i} {obj.name}")
         if obj.type != 'MESH':
-            continue
-        for mod in obj.modifiers:
-            if mod.type != 'SUBSURF':
-                continue    
-            mod.show_viewport = False
+            continue        
+        disable_subsurf_modifiers(obj)
+        #remove_inactive_uv_maps(obj)
+        make_active_UV_first(obj)
+
+    print("=== PRE-PROCESSING FINISHED ===")
     
     # CHOOSE EXPORT OPTIONS - based on target_format (gltf/gltf_godot)
     print(f"Gonna generate GLTF for target format: {target_format}")
     if target_format == "gltf": # Optimize for web presentation - adding draco compression
-        options = [["maximal",maximalGLTF | dracoMeshCompression], ["minimal", minimalGLTF | dracoMeshCompression]]
+        options = [
+            ["maximal", maximalGLTF | dracoMeshCompression],
+            ["minimal", minimalGLTF | dracoMeshCompression]
+            ]
     elif target_format == "gltf_godot": # Optimize for use in Godot
-        options = [["maximal",maximalGLTF], ["minimal", minimalGLTF]]
+        options = [
+            ["maximal", maximalGLTF],
+            ["minimal", minimalGLTF]
+            ]
     else:
         print("target_format needs to be gltf/gltf_godot!")
         exit(10)
@@ -75,7 +148,7 @@ def generate_gltf(json_result_path: str, target_format: str):
     with open(json_result_path, 'w') as f:
         json.dump(files, f, ensure_ascii=False, indent=4)
 
-
+# MARK: MAIN
 if __name__ == "__main__":
     addon_utils.enable("io_scene_gltf2")
     datafile = sys.argv[-1]


### PR DESCRIPTION
fixes #29 
fixes #30
fixes #28

- moves SUBSURF removal to separate func disable_subsurf_modifiers()
- fixes the pre-processing iteration by iterating over bpy.data.objects instead of bpy.context.selected_objects (we are in scripts, nothing is selected)
- bakes all procedural textures and set them in the material before export