### PR TITLE
Download original asset file in GLTF generation scripts

### DIFF
--- a/generate_gltf.py
+++ b/generate_gltf.py
@@ -28,7 +28,7 @@ def generate_gltf(asset_data, api_key, binary_path: str) -> bool:
   destination_directory = tempfile.gettempdir()
 
   # Download asset
-  asset_file_path = download.download_asset(asset_data, api_key=api_key, directory=destination_directory, filetype='resolution_2K')
+  asset_file_path = download.download_asset(asset_data, api_key=api_key, directory=destination_directory)
 
   # Unpack asset
   send_to_bg.send_to_bg(asset_data, asset_file_path=asset_file_path, script='unpack_asset_bg.py', binary_path=binary_path)

--- a/generate_gltf_godot.py
+++ b/generate_gltf_godot.py
@@ -31,7 +31,7 @@ def generate_gltf(asset_data, api_key, binary_path: str) -> bool:
   destination_directory = tempfile.gettempdir()
 
   # Download asset
-  asset_file_path = download.download_asset(asset_data, api_key=api_key, directory=destination_directory, filetype='resolution_2K')
+  asset_file_path = download.download_asset(asset_data, api_key=api_key, directory=destination_directory)
 
   # Unpack asset
   send_to_bg.send_to_bg(asset_data, asset_file_path=asset_file_path, script='unpack_asset_bg.py', binary_path=binary_path)


### PR DESCRIPTION
- if they are meant to run in parallel, then downgraded resolutions are not available